### PR TITLE
Feature/update-search-endpoint-to-new-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 This library is an Afosto search client plugin for the open-source <a href="https://github.com/algolia/instantsearch.js">InstantSearch.js</a> library (powered by Algolia). With this plugin you can use the amazing widgets of the InstantSearch.js library, while communicating with the Afosto search API.
 </p>
 
-## 🚧 Currently in development 🚧
-
 ## Installation
 
 ### Basic
@@ -114,7 +112,7 @@ For more information check the React InstantSearch [documentation](https://www.a
 ## Compatibility
 
 - InstantSearch.js v4
-- Node >= 12.10
+- Node >= 14
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afosto/instant-search-client",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "private": false,
   "description": "The Afosto InstantSearch client",
   "main": "./dist/afosto-instant-search.min.js",

--- a/playground/index.html
+++ b/playground/index.html
@@ -37,10 +37,10 @@
                     <h2>Brands</h2>
                     <div id="brand-list"></div>
 
-                    <h2>Color</h2>
-                    <div id="color-list"></div>
+                    <h2>Supplier</h2>
+                    <div id="supplier-list"></div>
 
-                    <h2>Price</h2>
+                    <h2>Length</h2>
                     <div id="range-slider"></div>
                 </div>
                 <div style="flex:1;padding:20px">
@@ -80,7 +80,7 @@
 
                 instantsearch.widgets.refinementList({
                     container: '#brand-list',
-                    attribute: 'merk',
+                    attribute: 'Brand',
                     operator: 'and',
                     searchable: false,
                     showMore: true,
@@ -88,17 +88,17 @@
                 }),
 
               instantsearch.widgets.refinementList({
-                container: '#color-list',
-                attribute: 'kleur',
+                container: '#supplier-list',
+                attribute: 'Supplier',
                 operator: 'and',
-                searchable: true,
+                searchable: false,
                 showMore: true,
                 showMoreLimit: 500,
               }),
 
                 instantsearch.widgets.rangeSlider({
                     container: '#range-slider',
-                    attribute: 'price',
+                    attribute: 'Length',
                     precision: 0,
                     step: 1,
                 }),
@@ -126,11 +126,15 @@
                             <div class="ais-Hits-list-item">
                               <img src="{{metadata.image}}" align="left" alt="{{metadata.name}}" width="100" />
                               <div class="hit-name">
-                                {{metadata.name}}
+                                {{title}}
                               </div>
-                              <div class="hit-release-date">Brand: {{metadata.brand}}</div>
+                              <div class="hit-release-date">Brand: {{Brand}}</div>
+                              <div class="hit-release-date">Length: {{Length}}</div>
                               <div class="hit-description">
-                                &euro;{{metadata.price}}
+                                {{description}}
+                              </div>
+                              <div class="price">
+                                &euro;{{price}}
                               </div>
                             </div>
                           `,

--- a/src/afostoInstantSearch.js
+++ b/src/afostoInstantSearch.js
@@ -30,7 +30,7 @@ const afostoInstantSearch = (proxyId, options) => {
         Accept: 'application/vnd.instantsearch+json',
         ...(requestOptions.headers || {}),
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ data: payload }),
     });
     const response = await searchResponse.json();
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 export const DEFAULT_OPTIONS = {
   allowEmptyQuery: true,
-  baseUrl: 'https://api.afosto.io/cnt/instant/search/{proxyId}',
+  baseUrl: 'https://afosto.io/api/instant/search/{proxyId}',
   hitsPerPage: 10,
   requestOptions: {},
   threshold: 1,


### PR DESCRIPTION
feat: update the default baseUrl to the new Afosto instant search API
feat: nest the search request payload in a data property
feat: change required node version to >= 14
chore: bump package version to 1.0.0
chore: remove development notice from README file
chore: update playground with filters that exist in the new API