### PR TITLE
Fix/pagination-offset-hits-per-page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afosto/instant-search-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "description": "The Afosto InstantSearch client",
   "main": "./dist/afosto-instant-search.min.js",

--- a/src/adapters/SearchRequestAdapter.js
+++ b/src/adapters/SearchRequestAdapter.js
@@ -85,9 +85,10 @@ const SearchRequestAdapter = () => {
    */
   const transformPagination = (request, options = {}) => {
     const { page, hitsPerPage } = request?.params ?? {};
-    const offset = page * hitsPerPage;
+    const limit = hitsPerPage || options.hitsPerPage;
+    const offset = page * limit;
 
-    return { limit: hitsPerPage || options.hitsPerPage, offset };
+    return { limit, offset };
   };
 
   /**


### PR DESCRIPTION
fix: search request pagination calculate offset not using hitsPerPage options fallback