### PR TITLE
Feature/combine-multiple-search-requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afosto/instant-search-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "description": "The Afosto InstantSearch client",
   "main": "./dist/afosto-instant-search.min.js",
@@ -52,6 +52,9 @@
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0"
+  },
+  "dependencies": {
+    "uuid": "^8.3.2"
   },
   "browserslist": [
     ">0.2%",

--- a/playground/index.html
+++ b/playground/index.html
@@ -66,10 +66,6 @@
               });
 
               search.addWidgets([
-                instantsearch.widgets.configure({
-                  facets: ['main_genre', 'release_year_range'],
-                }),
-
                 instantsearch.widgets.searchBox({
                   container: '#searchbox',
                 }),
@@ -84,9 +80,8 @@
 
                 instantsearch.widgets.dynamicWidgets({
                   container: '#dynamic-list',
-                  facets: [],
                   transformItems(_, { results }) {
-                    return results.facets.map(facet => facet.name);
+                    return Object.keys(results._rawResults[0].facets);
                   },
                   widgets: filterKeys.map((attribute) => (container) =>
                     instantsearch.widgets.panel({

--- a/src/adapters/SearchRequestAdapter.js
+++ b/src/adapters/SearchRequestAdapter.js
@@ -119,6 +119,7 @@ const SearchRequestAdapter = () => {
         indices: [request.indexName],
         q: query,
         threshold: options.threshold || DEFAULT_OPTIONS.threshold,
+        __queryID: request.__queryID,
         ...pagination,
       }];
     }, []);

--- a/src/adapters/SearchResponseAdapter.js
+++ b/src/adapters/SearchResponseAdapter.js
@@ -22,6 +22,7 @@ const SearchResponseAdapter = () => {
     const nbHits = results.count ?? 0;
     const nbPages = Math.ceil(nbHits / hitsPerPage);
     const index = results.id ?? request?.indexName;
+    const queryID = results.__queryID ?? index;
 
     return {
       facets,
@@ -33,7 +34,7 @@ const SearchResponseAdapter = () => {
       nbPages,
       page,
       query,
-      queryID: index,
+      queryID,
     };
   };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 export const DEFAULT_OPTIONS = {
   allowEmptyQuery: true,
-  baseUrl: 'https://afosto.io/api/instant/search/{key}',
+  baseUrl: 'https://afosto.app/api/instant/search/{key}',
   hitsPerPage: 10,
   requestOptions: {},
   settingsRequestOptions: {},


### PR DESCRIPTION
feat: change the default baseUrl domain from afosto.io to afosto.app
feat: combine multiple search contexts to a single search request
feat: add __queryID to every search context request
feat: search request adapter add __queryID to search context payload
feat: search response adapter add queryID to search context response
chore: playground remove facets configuration widget
chore: playground remove facets property of the dynamicWidgets
chore: playground dynamicWidgets transformItems return the facets of the raw response results
chore: bump version to 1.0.3